### PR TITLE
[Feature] Add timeout reset for accessibility users

### DIFF
--- a/Sources/Cocoa/Extensions/NotificationCenter+Extensions.swift
+++ b/Sources/Cocoa/Extensions/NotificationCenter+Extensions.swift
@@ -225,6 +225,11 @@ extension NotificationCenter.Event {
         observe(Notification.Name(rawValue: UIAccessibility.differentiateWithoutColorDidChangeNotification), callback)
     }
 
+    @discardableResult
+    public func accessibilityVoiceOverElementFocusedNotification(_ callback: @escaping () -> Void) -> NSObjectProtocol {
+        observe(UIAccessibility.elementFocusedNotification, callback)
+    }
+
     // MARK: - UIContentSizeCategory
 
     /// Posted when the user changes the preferred content size setting.

--- a/Sources/Swift/Components/Dates and Timers/IdleTimer/IdleTimer+Gesture.swift
+++ b/Sources/Swift/Components/Dates and Timers/IdleTimer/IdleTimer+Gesture.swift
@@ -53,6 +53,10 @@ extension IdleTimer {
     final class WindowContainer {
         private let timer: InternalTimer
 
+        /// When VoiceOver is on we need to keep track of movement so we are not locking user
+        /// out accidnetally.
+        private var voiceOverElementObserver: NSObjectProtocol?
+
         /// The timeout duration in seconds, after which idle timer notification is
         /// posted.
         var timeoutDuration: TimeInterval {
@@ -64,6 +68,13 @@ extension IdleTimer {
             timer = .init(timeoutAfter: 0) {
                 NotificationCenter.default.post(name: UIApplication.didTimeOutUserInteractionNotification, object: nil)
             }
+            voiceOverElementObserver = NotificationCenter.on.accessibilityVoiceOverElementFocusedNotification { [weak self] in
+                self?.timer.wake()
+            }
+        }
+
+        deinit {
+            NotificationCenter.remove(voiceOverElementObserver)
         }
 
         func add(_ window: UIWindow) {


### PR DESCRIPTION
**Motivation**

We use a gesture recognizer for a user to reset the timer which is not triggered when VoiceOver is on due to fact that VO is taking over the screen and handle gestures on its own. What could potentially happen is that the user will read the longer text and after 3 mins he will be locked out even if the user was moving on the screen.

Due to this, I am adding one more reset timer - when the user is changing the focusing element.

**Discussion**

My initial solution was to trigger reset when the user touches display but due to VO API, we are not able to receive that event. This is not an ideal solution to this problem but it's the one which should cover 90% of cases.